### PR TITLE
feat: reformat readme, structure components

### DIFF
--- a/principles/design-for-use.md
+++ b/principles/design-for-use.md
@@ -1,0 +1,69 @@
+# Design for use
+
+To build complex applications that are user-friendly, focus on:
+- what is the main purpose of the application?
+- who is the application for?
+- how will users of the application achieve their goals?
+
+All applications on the DHIS2 platform should consider their user-experience. Not all apps can be simple, but all can be understandable by their intended users. Do not focus on simplicity, **focus on clarity**. An application should enable users to solve problems, understand information and achieve their goals.
+
+## How to build usable, understandable applications
+
+#### 1. Define the core purpose of the application
+What will the application do? What won't it do? These are important questions to ask and answer before you start building. A clear, concise 'application definition' provides a guiding principle for all the design and implementation decisions.
+
+Examples of 'application definitions' for core DHIS2 apps:
+
+**Dashboards**
+`Build and view dashboards with saved visualizations and static information`
+
+**Data Visualizer**
+`Create, save and share data visualisations from stored data`
+
+**Capture**
+`Create, edit and view data stored in event and tracker programs. View and edit data attached to tracked entities`
+
+**Scheduler**
+`Set up automatic system jobs via a visual user interface`
+
+Remember, an application definition doesn't need to be simple, but it should be concise and focused. The point is not to try to list all the functionality, that will come later, but to try to understand the core purpose of the application. This core purpose will help throughout the design and development process. New or suggested features can be evaluated against the definition: "Does this suggested feature fit the core purpose of the application?".
+
+When the core purpose of the application is known, the application definition, then features can be discussed and decided upon. Often it will be clear from the definition what features are required.
+
+#### 2. Understand the users
+After establishing an application definition and an understanding of the required features,focus on who will be using the application. Who are the potential users, who will not be using it? Why do users need this application? DHIS2 is unique in it's flexibility, it is difficult to know who will use the application when there are implementations all over the world solving different problems. But, as much as possible, try to identify the type of user that is expected to benefit most from the application. Research to understand who the users may be. What level of technical skills do they have? What typical network access do they have? What other apps do they use regularly? Try to gather as much information as possible, ideally by asking questions to potential users and listening and understanding their responses. Avoid making assumptions about how users work, or what they need.
+
+Understanding potential users of the application will inform the whole design and development process. It is important to spend time at this stage to establish as much detail as possible. So, rather than simply "Data entry workers", it is better to know that users are "Data entry workers, not used to working with technology, logging in once per month, reading all on-screen instructions." Not all users will fit this pattern, but is there some common ground for the majority of users?
+
+#### 3. Design for the users
+'User-centered Design' is the design of solutions that are driven by the goals of a user. Applications that are 'user-centered' are built to reflect the way a user works, not necessarily how the technology works.
+
+All applications on the DHIS2 platform should be user-centered. Design and implementation decisions should always be considered first and foremost from how they will impact users. Implementation and technical decisions should follow after the user has been considered.
+
+Remember that an application developer or designer does not always have the ideal perspective of how applications should work, or how the interface should be laid out. As much as possible it is always best to refer to the user, using the research gathered in [step two](#2-understand-the-users). Applications interfaces should reflect where a user expects to find controls and information, not necessarily how they are arranged in the system or database.
+
+
+#### 4. Allow configuration, but only where needed
+Many DHIS2 apps are complex and flexible. They are powerful precisely because they allow for so many different ways of working. This comes with a trade-off in usability. Presenting a user with many options and configurations can be confusing and intimidating.
+
+Understanding potential users is key to establishing the right balance between complexity and simplicity. How much configuration should be possible, and how should it be done?
+
+Consider this sample application and its users:
+- 90% of users will use the application with the 'default' options and configuration
+- users that do want to customise the interface or workflow are technically proficient
+This scenario is an obvious case for displaying the configuration options on a secondary screen. If 90% of the users will never need those options it would be best to hide them, otherwise they would cause unecessary confusion and uncertainty. Expert users that wanted to configure their application would be able to do so, but it isn't the main use case.
+
+Thinking about the opposite scenario for another application and its users:
+- there are few common use cases, all user groups have different requirements
+- different users in the same user groups work in different ways, the workflow is highly personal
+In this scenario it is important that the configuration options are obvious and available to all users. Options should not be hidden and it should be quick to adjust the interface. (In this extreme example, is it even right to have a single application? That would be a question to address in [step one](#1-define-the-core-purpose-of-the-application)).
+
+Rarely is it so well defined. Most applications will have user requirements that hover in the middle of these two example scenarios. The important thing to keep in mind is that the amount of customisation and configuration included in an application should always be a conscious choice. Do not expose all options just because they exist. Only show configuration options that are actually useful and relevant. Decisions regarding the options included, and how they are displayed, should always be taken from a 'user-centered' perspective.
+
+
+#### 5. Listen to feedback
+The application development process does not end when the application is released. Users will start using the application and there will always be feedback. It is important to listen to all feedback. Use the feedback to better understand how users work. Not all feedback needs to be implemented, but it should always be heard.
+
+Some feedback will come up often enough and have enough impact that the application should be updated or changed. Make sure, before making changes, that any change would be a positive one for the majority of users. All users have preferences, ensure that changes aren't made based on a vocal minority expressing a preference. Keep the application defenition and main user group in mind at all times.
+
+Remember that all changes will need to be documented and may impact the relevance of training materials, so only make major, or breaking, changes when it will be a meaningful positive to users.

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ The DHIS2 Design System is a collection of design principles and a library of UI
 
 The design system consists of two sections:
 
-- [Design Principles](#design-principles): These principles are the guidelines that inform how DHIS2 apps should work and look. All designers and developers working on DHIS2 apps should be familiar with these guidelines.
+- [Principles](#design-principles): These principles are the guidelines that inform how DHIS2 apps should work and look. All designers and developers working on DHIS2 apps should be familiar with these guidelines.
 - [Components](#components): A collection of UI elements that can be, and should be, reused across all DHIS2 apps. The components have been designed with DHIS2 use cases in mind. Using these components means more time spent focusing on building a great user experience and less time redesigning and rebuilding common components. Each component has it's own guidelines for use.
 
 ---
@@ -74,7 +74,7 @@ Each component has guidelines for use, explanations of the different options and
 Want to get started designing and building DHIS2 apps? Follow these steps:
 
 #### 1. Get to know the Design System principles
-It is important to be familiar with the principles of the design system. These principles cover how apps should work and look. It is important that all apps are built with the principles in mind, when all DHIS2 apps follow the same principles it becomes easier for all users to work across multiple apps without needing to relearn patterns or meanings.
+It is important to be familiar with the [principles](#design-principles) of the design system. These principles cover how apps should work and look. It is important that all apps are built with the principles in mind, when all DHIS2 apps follow the same principles it becomes easier for all users to work across multiple apps without needing to relearn patterns or meanings.
 
 #### 2. Understand the use case
 Before starting on the design of a DHIS2 app it is important that you research and understand the use case. What will this app enable users to do? Why is this app useful? What will the app **not** do? It is important that DHIS2 apps solve real use cases in a simple, manageable way. The most useful apps are the ones that do few things very well. Make sure apps are focused on these use cases.
@@ -86,7 +86,7 @@ Understanding the use case before starting on the design and building will save 
 #### 3. Design with components
 When the use cases are clear and all the requirements are understood it is time to start designing mockups/prototypes of the app. Building prototypes and mockups first means you can test these with potential users, finding out what works and what needs to be revised.
 
-Where possible, always use components available from the design system component library. These components have been designed and built with DHIS2 in mind. The pages for each component below have guidelines for use and explanations of the options and types available. Reading through the component pages will help to understand which components should be used where, and why.
+Where possible, always use components available from the design system [component library](#components). These components have been designed and built with DHIS2 in mind. The pages for each component below have guidelines for use and explanations of the options and types available. Reading through the component pages will help to understand which components should be used where, and why.
 
 <!-- Check out the [resources](#resources) section to find the UI component library available for different design tools. -->
 

--- a/readme.md
+++ b/readme.md
@@ -1,42 +1,119 @@
 # DHIS2 Design System
-This is the temporary home for the DHIS2 Design System while it is under development. The design system consists of principles to guide design of DHIS2 applications, as well as a library of flexible, reusable ui components.
+The DHIS2 Design System is a collection of design principles and a library of UI components for designing apps for the DHIS2 platform. Using this system you can design and build apps that are usable, powerful and consistent with other DHIS2 apps.
+
+The design system consists of two sections:
+
+- **Design Principles**: These principles are the guidelines that inform how DHIS2 apps should work and look. All designers and developers working on DHIS2 apps should be familiar with these guidelines.
+- **Components**: A collection of UI elements that can be, and should be, reused across all DHIS2 apps. The components have been designed with DHIS2 use cases in mind. Using these components means more time spent focusing on building a great user experience and less time redesigning and rebuilding common components. Each component has it's own guidelines for use.
+
+---
+
+##### Design System Contents
+- [Principles](#design-principles)
+- [Components](#components)
+
+
+##### Using the system
+- [Designing DHIS2 apps](#designing-dhis2-apps)
+- [Resources](#resources)
+- [Contributing and Feedback](#contribting-and-feedback)
+
+---
 
 ## Design Principles
-* [Typography](principles/typography.md)
-* [Color](principles/color.md)
-* [Spacing, Alignment, Stacking](principles/spacing-alignment.md)
-* [Content & Communication](principles/content-communication.md)
-* [Icons](principles/icons.md)
+- Design for use
+- [Typography](principles/typography.md)
+- [Color](principles/color.md)
+- [Spacing, Alignment, Stacking](principles/spacing-alignment.md)
+- [Content & Communication](principles/content-communication.md)
+- [Icons](principles/icons.md)
 
 ## Components
-The DHIS2 ui component system is based on atomic design principles, reducing components into reusable atoms and molecules. Each component has recommended usages.
-### Atoms
-* [Avatar](atoms/avatar.md)
-* [Button](atoms/button.md)
-* [Card](atoms/card.md)
-* [Checkbox](atoms/checkbox.md)
-* [Chip](atoms/chip.md)
-* [Elevation](atoms/elevation.md)
-* [File Input](atoms/fileinput.md)
-* [Input field](atoms/inputfield.md)
-* [Loading indicators](atoms/loading.md)
-* [Radio button](atoms/radio.md)
-* [Switch](atoms/switch.md)
-* [Tooltip](atoms/tooltip.md)
+Each component has guidelines for use, explanations of the different options and types available and examples of how the component is used in real DHIS2 apps. Components are organised by usage.
 
-### Molecules
-* [Comment](molecules/comment.md)
-* [Modal](molecules/modal.md)
-* [Menu](atoms/menu.md)
-* [Notice box](molecules/notice-box.md)
-* [Pagination](molecules/pagination.md)
-* [Popover](molecules/popover.md)
-* [Select](molecules/select.md)
-* [Tabs](molecules/tab.md)
-* [Alert bar](molecules/alertbar.md)
-* Tree
+#### Action
+- [Button](atoms/button.md)
+- [Chip](atoms/chip.md)
+- [Menu](atoms/menu.md)
+#### Data display
+- [Avatar](atoms/avatar.md)
+- [Notice box](molecules/notice-box.md)
+- [Popover](molecules/popover.md)
+- [Table](organisms/table.md)
+- [Tooltip](atoms/tooltip.md)
+- data table
+- conversation
+#### Data entry
+- [Checkbox](atoms/checkbox.md)
+- [Comment](molecules/comment.md)
+- [File Input](atoms/fileinput.md)
+- [Input field](atoms/inputfield.md)
+- [Organisation Unit Tree](organisms/organisation-unit-tree/org-unit-tree.md)
+- [Radio button](atoms/radio.md)
+- [Select](molecules/select.md)
+- [Switch](atoms/switch.md)
+- transfer
+#### Feedback
+- [Alert bar](molecules/alertbar.md)
+- [Loading indicators](atoms/loading.md)
+#### Layout
+- [Card](atoms/card.md)
+- [Modal](molecules/modal.md)
+#### Navigation
+- [Pagination](molecules/pagination.md)
+- [Tabs](molecules/tab.md)
+#### Utilities
+- [Elevation](atoms/elevation.md)
+- [Header Bar](organisms/header-bar.md)
+- spacing
+- typography
 
-### Organisms
-* [Header Bar](organisms/header-bar.md)
-* [Table](organisms/table.md)
-* [Organisation Unit Tree](organisms/organisation-unit-tree/org-unit-tree.md)
+---
+
+## Designing DHIS2 apps
+Want to get started designing and building DHIS2 apps? Follow these steps:
+
+#### 1. Get to know the Design System principles
+It is important to be familiar with the principles of the design system. These principles cover how apps should work and look. It is important that all apps are built with the principles in mind, when all DHIS2 apps follow the same principles it becomes easier for all users to work across multiple apps without needing to relearn patterns or meanings.
+
+#### 2. Understand the use case
+Before starting on the design of a DHIS2 app it is important that you research and understand the use case. What will this app enable users to do? Why is this app useful? What will the app **not** do? It is important that DHIS2 apps solve real use cases in a simple, manageable way. The most useful apps are the ones that do few things very well. Make sure apps are focused on these use cases.
+
+Understanding the use case before starting on the design and building will save time later. It is much easier to make changes to draft ideas than finished apps.
+
+Find out more by reading the principle: Design for use.
+
+//Design for use
+design with the end user in mind. gather their requirements and build for them, not for the tech.
+Read more about Designing for use (link)
+
+#### 3. Design with components
+When the use cases are clear and all the requirements are understood it is time to start designing mockups/prototypes of the app. Building prototypes and mockups first means you can test these with potential users, finding out what works and what needs to be revised.
+
+Where possible, always use components available from the design system component library. These components have been designed and built with DHIS2 in mind. The pages for each component below have guidelines for use and explanations of the options and types available. Reading through the component pages will help to understand which components should be used where, and why.
+
+Check out the [resources](#resources) section to find the UI component library available for different design tools.
+
+---
+
+## Resources
+All components included in the design system are available as a Sketch library that can be imported and reused across your designs. The Sketch library will be constantly updated, be sure to check back to grab the latest version.
+
+TODO Sketch library image
+TODO Sketch library download link
+
+---
+
+## Contributing and Feedback
+
+### Contributing to the design system
+
+Contributions to the design system are welcome. If there is a component that you have designed and/or built that you think could be useful for others, please send it in! A component can be detailed using the [example template](extras/component-template.md), and a PR can be opened for submission.
+
+The DHIS2 Design System is based upon principles of [Atomic Design](http://atomicdesign.bradfrost.com/table-of-contents/). Submitted components should follow this system, using existing atoms and molecules to compose new components where possible.
+
+### Feedback and issues
+
+[Open an issue](https://github.com/dhis2/design-system/issues) to contribute feedback regarding a component in the design system. Feedback is always appreciated and helps to make the design system more robust and powerful.
+
+---

--- a/readme.md
+++ b/readme.md
@@ -3,8 +3,8 @@ The DHIS2 Design System is a collection of design principles and a library of UI
 
 The design system consists of two sections:
 
-- **Design Principles**: These principles are the guidelines that inform how DHIS2 apps should work and look. All designers and developers working on DHIS2 apps should be familiar with these guidelines.
-- **Components**: A collection of UI elements that can be, and should be, reused across all DHIS2 apps. The components have been designed with DHIS2 use cases in mind. Using these components means more time spent focusing on building a great user experience and less time redesigning and rebuilding common components. Each component has it's own guidelines for use.
+- [Design Principles](#design-principles): These principles are the guidelines that inform how DHIS2 apps should work and look. All designers and developers working on DHIS2 apps should be familiar with these guidelines.
+- [Components](#components): A collection of UI elements that can be, and should be, reused across all DHIS2 apps. The components have been designed with DHIS2 use cases in mind. Using these components means more time spent focusing on building a great user experience and less time redesigning and rebuilding common components. Each component has it's own guidelines for use.
 
 ---
 
@@ -21,11 +21,11 @@ The design system consists of two sections:
 ---
 
 ## Design Principles
-- Design for use
-- [Typography](principles/typography.md)
-- [Color](principles/color.md)
-- [Spacing, Alignment, Stacking](principles/spacing-alignment.md)
+<!-- - Design for use -->
 - [Content & Communication](principles/content-communication.md)
+- [Spacing, Alignment, Stacking](principles/spacing-alignment.md)
+- [Color](principles/color.md)
+- [Typography](principles/typography.md)
 - [Icons](principles/icons.md)
 
 ## Components
@@ -41,8 +41,8 @@ Each component has guidelines for use, explanations of the different options and
 - [Popover](molecules/popover.md)
 - [Table](organisms/table.md)
 - [Tooltip](atoms/tooltip.md)
-- data table
-- conversation
+<!-- - data table -->
+<!-- - conversation -->
 #### Data entry
 - [Checkbox](atoms/checkbox.md)
 - [Comment](molecules/comment.md)
@@ -52,7 +52,7 @@ Each component has guidelines for use, explanations of the different options and
 - [Radio button](atoms/radio.md)
 - [Select](molecules/select.md)
 - [Switch](atoms/switch.md)
-- transfer
+<!-- - transfer -->
 #### Feedback
 - [Alert bar](molecules/alertbar.md)
 - [Loading indicators](atoms/loading.md)
@@ -65,8 +65,8 @@ Each component has guidelines for use, explanations of the different options and
 #### Utilities
 - [Elevation](atoms/elevation.md)
 - [Header Bar](organisms/header-bar.md)
-- spacing
-- typography
+<!-- - spacing -->
+<!-- - typography -->
 
 ---
 
@@ -81,26 +81,25 @@ Before starting on the design of a DHIS2 app it is important that you research a
 
 Understanding the use case before starting on the design and building will save time later. It is much easier to make changes to draft ideas than finished apps.
 
-Find out more by reading the principle: Design for use.
-
-//Design for use
-design with the end user in mind. gather their requirements and build for them, not for the tech.
-Read more about Designing for use (link)
+<!-- Find out more by reading the principle: Design for use. -->
 
 #### 3. Design with components
 When the use cases are clear and all the requirements are understood it is time to start designing mockups/prototypes of the app. Building prototypes and mockups first means you can test these with potential users, finding out what works and what needs to be revised.
 
 Where possible, always use components available from the design system component library. These components have been designed and built with DHIS2 in mind. The pages for each component below have guidelines for use and explanations of the options and types available. Reading through the component pages will help to understand which components should be used where, and why.
 
-Check out the [resources](#resources) section to find the UI component library available for different design tools.
+<!-- Check out the [resources](#resources) section to find the UI component library available for different design tools. -->
 
 ---
 
 ## Resources
-All components included in the design system are available as a Sketch library that can be imported and reused across your designs. The Sketch library will be constantly updated, be sure to check back to grab the latest version.
+All components included in the design system will soon be available as a Sketch library that can be imported and reused across your designs.
 
-TODO Sketch library image
-TODO Sketch library download link
+<!-- The Sketch library will be constantly updated, be sure to check back to grab the latest version. -->
+
+<!-- TODO Sketch library image -->
+<!-- TODO Sketch library download link -->
+`Downloadable library coming soon!`
 
 ---
 


### PR DESCRIPTION
- Update the readme with more information on using Design System
- adjust structure of components list, now listed by usage rather than Atomic type
- add 'Design for use' principle